### PR TITLE
Add cybersecurity news web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ page will automatically update the time for each listed zone every second.
 The `peruvian-cooking-websites` folder contains a small web page that lists a
 few popular sites for exploring Peruvian cuisine. Open
 `peruvian-cooking-websites/index.html` in your browser to see the links.
+
+## Cybersecurity News App
+
+The `cybersecurity-news-app` directory contains a very small web application that serves an HTML page with placeholder text for cybersecurity news. It uses Node's built-in `http` module so it works offline. Run it with `npm start` inside that folder and visit `http://localhost:3000` in your browser.

--- a/cybersecurity-news-app/index.html
+++ b/cybersecurity-news-app/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Noticias de Ciberseguridad</title>
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <h1>Noticias de Ciberseguridad</h1>
+  <div id="news">
+    <ul>
+      <li><strong>Placeholder:</strong> No se pueden mostrar noticias en tiempo real sin conexión a Internet. Sustituya este texto con actualizaciones obtenidas de una API de noticias.</li>
+    </ul>
+  </div>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/cybersecurity-news-app/package.json
+++ b/cybersecurity-news-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cybersecurity-news-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/cybersecurity-news-app/server.js
+++ b/cybersecurity-news-app/server.js
@@ -1,0 +1,36 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/') {
+    fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {
+      if (err) {
+        res.writeHead(500);
+        return res.end('Error loading index.html');
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    });
+  } else if (req.url.startsWith('/static/')) {
+    const filePath = path.join(__dirname, req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        return res.end('Not found');
+      }
+      const ext = path.extname(filePath);
+      const contentType = ext === '.css' ? 'text/css' : 'application/javascript';
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(data);
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/cybersecurity-news-app/static/app.js
+++ b/cybersecurity-news-app/static/app.js
@@ -1,0 +1,1 @@
+console.log('App loaded');

--- a/cybersecurity-news-app/static/styles.css
+++ b/cybersecurity-news-app/static/styles.css
@@ -1,0 +1,8 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+h1 {
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- add new `cybersecurity-news-app` with a simple Node HTTP server
- include placeholder news page and basic styles
- document how to start the app in README

## Testing
- `npm start` in `cybersecurity-news-app`

------
https://chatgpt.com/codex/tasks/task_e_6886f45736a88323a87654f02ce42f45