### PR TITLE
Add ENTILABS landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ few popular sites for exploring Peruvian cuisine. Open
 ## Cybersecurity News App
 
 The `cybersecurity-news-app` directory contains a very small web application that serves an HTML page with placeholder text for cybersecurity news. It uses Node's built-in `http` module so it works offline. Run it with `npm start` inside that folder and visit `http://localhost:3000` in your browser.
+
+## ENTILABS Landing Page
+
+The `entilabs-web-app` folder contains a basic React front‑end that introduces
+ENTILABS, a company focused on application development, automation of critical
+processes and AI agents. Open `entilabs-web-app/index.html` in your browser to
+view the announcement and contact information.

--- a/entilabs-web-app/app.js
+++ b/entilabs-web-app/app.js
@@ -1,0 +1,12 @@
+function App() {
+  return (
+    <div>
+      <h1>ENTILABS</h1>
+      <p>Nos especializamos en desarrollo de aplicaciones, automatización de procesos críticos y agentes de IA. Aplicamos la seguridad en todas las fases del desarrollo.</p>
+      <p><strong>¡Lanzamiento próximo!</strong></p>
+      <p>Contacto: <a href="mailto:mpajuelo35@gmail.com">mpajuelo35@gmail.com</a></p>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/entilabs-web-app/index.html
+++ b/entilabs-web-app/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ENTILABS</title>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple React landing page for ENTILABS
- document the new app in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68885a43a0808323aede9cba9eb9e2db